### PR TITLE
Настройка конфигурации activity_spikes для реального запуска на больших данных

### DIFF
--- a/core/config/default.yaml
+++ b/core/config/default.yaml
@@ -38,7 +38,7 @@ detectors:
 
   activity_spikes:
     enabled: true
-    time_resolution: '10s'  
+    time_resolution: '1H'  
     window_size: 5
     top_n: 10
     schedule_file: "/content/drive/MyDrive/aggrs_tv_program_epg_plan.csv"

--- a/core/config/local.yaml
+++ b/core/config/local.yaml
@@ -38,7 +38,7 @@ isolation_forest:
 
   activity_spikes:
     enabled: true
-    time_resolution: "10s"
+    time_resolution: "1H"
     window_size: 5
     top_n: 10
     schedule_file: "data/aggrs_tv_program_epg_plan.csv"


### PR DESCRIPTION
Детектор ранее определял активность каждые 10 секунд, хотя оптимально было бы каждый час, из за этого запуск требовал много времени и производственных мощностей. Такая чувствительность была выставлена ранее для малых объёмов данных, чтобы быстро и наглядно показать работу фреймворка. Теперь же настройки должны позволять запуск и на гораздо больших данных. Конечный пользователь в конце концов может сам изменять файлы в папке config под свои нужды.